### PR TITLE
Prefix regen ids with r-

### DIFF
--- a/src/newganmanager/test/test.xml
+++ b/src/newganmanager/test/test.xml
@@ -15,7 +15,7 @@
                 -->
 
         <list id="maps">
-            <record from="African/African1" to="graphics/pictures/person/0123456789/portrait"/>
+            <record from="African/African1" to="graphics/pictures/person/r-0123456789/portrait"/>
 
         </list>
 </record>

--- a/src/profile_manager.py
+++ b/src/profile_manager.py
@@ -77,7 +77,7 @@ class Profile_Manager(config_manager.Config_Manager):
             xml_string = []
 
         for dat in data:
-            xml_string.append("<record from=\"{}\" to=\"graphics/pictures/person/{}/portrait\"/>".format(dat[1]+"/"+dat[2], dat[0]))
+            xml_string.append("<record from=\"{}\" to=\"graphics/pictures/person/r-{}/portrait\"/>".format(dat[1]+"/"+dat[2], dat[0]))
 
         xml_players = "\n".join(xml_string)
         xml_config = config_template.replace("[players]", xml_players)

--- a/src/test_app.py
+++ b/src/test_app.py
@@ -69,13 +69,13 @@ class Test_Xml_Writing(unittest.TestCase):
 
     def test_write_xml_template_string_formatting(self):
         for xml_player, player in zip(self.xml_data, self.data):
-            self.assertEqual("<record from=\""+player[1]+"/"+player[2]+"\" to=\"graphics/pictures/person/"+player[0]+"/portrait\"/>", xml_player)
+            self.assertEqual("<record from=\""+player[1]+"/"+player[2]+"\" to=\"graphics/pictures/person/r-"+player[0]+"/portrait\"/>", xml_player)
 
     def test_write_xml_players_mapped_in_file(self):
         with open(self.pm.prf_cfg['img_dir']+"config.xml", 'r', encoding="UTF-8") as fp:
             xml_file = fp.read()
         for player in self.data:
-            self.assertIn("<record from=\""+player[1]+"/"+player[2]+"\" to=\"graphics/pictures/person/"+player[0]+"/portrait\"/>", xml_file)
+            self.assertIn("<record from=\""+player[1]+"/"+player[2]+"\" to=\"graphics/pictures/person/r-"+player[0]+"/portrait\"/>", xml_file)
 
     def test_write_xml_no_file_endings(self):
         with open(self.pm.prf_cfg['img_dir']+"config.xml", 'r', encoding="UTF-8") as fp:


### PR DESCRIPTION
Aims to resolve https://github.com/Maradonna90/NewGAN-Manager/issues/186 by prefixing player ids during the writing of portrait records