### PR TITLE
fix: MacOS build

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         briefcase create
         briefcase build
-        briefcase package --no-sign
+        briefcase package --adhoc-sign
     - name: Save Installer
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
`--no-sign` is no longer a valid option. This updates the workflow to use `--adhoc-sign` instead